### PR TITLE
revert to using library calls

### DIFF
--- a/sc129.c
+++ b/sc129.c
@@ -4,7 +4,7 @@
 
 static unsigned int _address = SC129_DEFAULT_ADDRESS;
 
-bool __LIB__ SC129_setAddress(unsigned int address) __z88dk_fastcall {
+bool __LIB__ SC129_setAddress_fastcall(unsigned int address) __smallc __z88dk_fastcall {
 	if (address < 256) {
 		_address = address;
 		return true;
@@ -13,7 +13,7 @@ bool __LIB__ SC129_setAddress(unsigned int address) __z88dk_fastcall {
 	return false;
 }
 
-bool __LIB__ SC129_write(unsigned int value) __z88dk_fastcall {
+bool __LIB__ SC129_write_fastcall(unsigned int value) __smallc __z88dk_fastcall {
 	if (value < 256) {
 		outp(_address, value);
 		return true;
@@ -22,6 +22,6 @@ bool __LIB__ SC129_write(unsigned int value) __z88dk_fastcall {
 	return false;
 }
 
-unsigned int __LIB__ SC129_read(void) __z88dk_fastcall {
+unsigned int __LIB__ SC129_read_fastcall (void) __smallc __z88dk_fastcall {
 	return inp(_address);
 }

--- a/sc129.h
+++ b/sc129.h
@@ -24,19 +24,25 @@
  * @param address The address to set (0 - 255).
  * @returns true if valid address set; Otherwise, false.
  */
-extern bool __LIB__ SC129_setAddress(unsigned int address) __z88dk_fastcall;
+extern bool __LIB__ SC129_setAddress(unsigned int address) __smallc;
+extern bool __LIB__ SC129_setAddress_fastcall(unsigned int address) __smallc __z88dk_fastcall;
+#define SC129_setAddress SC129_setAddress_fastcall
 
 /**
  * Writes a value to the output port of the Digital I/O module.
  * @param value The value to write (0 - 255);
  * @returns true if a valid value was written; Otherwise, false.
  */
-extern bool __LIB__ SC129_write(unsigned int value) __z88dk_fastcall;
+extern bool __LIB__ SC129_write(unsigned int value) __smallc;
+extern bool __LIB__ SC129_write_fastcall(unsigned int value) __smallc __z88dk_fastcall;
+#define SC129_write SC129_write_fastcall
 
 /**
  * Reads a value from the input port of the Digital I/O module.
  * @returns an 8bit value read from the port (0 - 255);
  */
-extern unsigned int __LIB__ SC129_read(void) __z88dk_fastcall;
+extern unsigned int __LIB__ SC129_read(void) __smallc;
+extern unsigned int __LIB__ SC129_read_fastcall(void) __smallc __z88dk_fastcall;
+#define SC129_read SC129_read_fastcall
 
 #endif

--- a/sc129tst.c
+++ b/sc129tst.c
@@ -20,19 +20,23 @@
 __sfr __at SC129_DEFAULT_ADDRESS io_port;   // Change this to match the address the jumpers are set for.
 
 void main() {
+
+	unsigned int val;
+
 	printf("\n\nSC129 Test v1.0 by Cyrus Brunner\n\n");
 	printf("Make sure each output pin of the SC129 is connected to it's\n");
 	printf("corresponding input pin and then press any key to continue...\n");
 	fgetc_cons();
 	printf("Beginning SC129 test (values 0 - 255)...\n\n");
 	msleep(1*18432/4);          // default scz180 CPU 18432000 Hz / default CPM CPU 4000000 Hz
-	// SC129_setAddress(SC129_DEFAULT_ADDRESS);  // Change this to match the address the jumpers are set for.
+	SC129_setAddress(SC129_DEFAULT_ADDRESS);  // Change this to match the address the jumpers are set for.
 
-	unsigned int val = 0;
 	for (unsigned int i = 0; i < 256; i++) {
-		io_port = i;            // SC129_write(i);
+//		io_port = i;            // SC129_write(i);
+		SC129_write(i);
 		msleep(5*18432/40);     // default scz180 CPU 18432000 Hz / default CPM CPU 4000000 Hz
-		val = io_port;          // val = SC129_read();
+//		val = io_port;          // val = SC129_read();
+		val = SC129_read();
 		printf("Output = %3d, Input = %3d - ", i, val);
 		if (val != i) {
 			printf("ERROR Value mismatch!\n");
@@ -42,7 +46,8 @@ void main() {
 		}
 	}
 
-	io_port = 0;                // SC129_write(0x00);    // Make sure the all the output pins (and LEDs) are off.
+//	io_port = 0;                // SC129_write(0x00);    // Make sure the all the output pins (and LEDs) are off.
+	SC129_write(0x00);
 	printf("\nDONE!");
 	exit(0);
 }


### PR DESCRIPTION
I've resolved all my hardware issues, and now that's done I've put all your calls back in place as they were.
They were always working. Just not on my hardware :man_facepalming: 

Probably the thing I should note was that sampling input was much slower than setting output on Spencer's Digital I/O Module.
IDK but that might be the cause of the issues you're having with reading the inputs on Stephen's solution too?

I had to rebuild RomWBW to insert the maximum number of I/O wait states (at 36MHz) to get the library `inp()` to work (total 4 I/O Wait). Lucky the Z180 is flexible enough to do that. If you try the macro `M_INP(0)` you might find it a little slower than the code generated by your function using `inp()`, and therefore be on the verge of working.